### PR TITLE
Add module functions for interacting with the wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,56 +1,73 @@
 python-clef
 =================================
+
 A Python wrapper for the [Clef](https://getclef.com/) API. Authenticate a user and access their information in two lines of code. 
 
 
-Requires
---------
-* requests
-
 Installation
 ------------
+
 Install using pip:        
+
  ```
  pip install clef
  ```
 
-
 Getting Started
 -----------
-The Clef API uses OAuth2 for authentication. Pass your credentials to the ClefAPI constructor and make
-a single call to handle the handshake and retrieve user information.
 
-#### Get your credentials
-[Create a Clef application](http://docs.getclef.com/v1.0/docs/creating-a-clef-application) to get your App ID and App secret
+The Clef API lets you retrieve information about a user after they log in to your site with Clef. 
+
+#### Get your API credentials
+
+[Create a Clef application](http://docs.getclef.com/v1.0/docs/creating-a-clef-application) to get your App ID and App secret.
 
 #### Add the Clef button
-The [button](http://docs.getclef.com/v1.0/docs/adding-the-clef-button) has a `data-redirect-url` which is where you will handle the OAuth callback. It can be customized or generated for you.
+
+The [Clef button](http://docs.getclef.com/v1.0/docs/adding-the-clef-button) has a `data-redirect-url`, which is where you can retrieve user information.
 
 Usage
 -----
 
 #### Logging in a user
-When a user logs in with Clef on their phone, Clef will send a code to the redirect url you defined in the button, which is where you handle the OAuth handshake:
+
+When a user logs in with Clef, the browser will redirect to your `data-redirect-url`. To retrieve user information, call `get_login_information` in that endpoint: 
+
 ``` 
-from clef import clef
+import clef
 
-code = request.args.get("code")
-api = clef.ClefAPI(app_id=YOUR_APP_ID, app_secret=YOUR_APP_SECRET)
-user_info = api.get_user_info(code=code)
+clef.initialize(app_id=YOUR_APP_ID, app_secret=YOUR_APP_SECRET)
+
+# In your redirect URL route: 
+code = request.args.get('code')
+user_information = clef.get_login_information(code=code)
 ```
+
+For what to do after getting user information, check out our documentation on
+[Associating users](http://docs.getclef.com/v1.0/docs/persisting-users).
+
 #### Logging out a user
-When you configure your application, you also set up a logout webhook URL. Clef sends a POST request to this URL whenever a user who has logged in with Clef logs out so you can handle logging out the user and storing a logout timestamp.
+
+When you configure your Clef integration, you can also set up a logout hook URL. Clef sends a POST to this URL whenever a user logs out with Clef, so you can log them out on your website too.
 
 ```
-from clef import clef
+import clef
 
+clef.initialize(app_id=YOUR_APP_ID, app_secret=YOUR_APP_SECRET)
+
+# In your logout hook route:
 logout_token = request.form.get("logout_token")
-api = clef.ClefAPI(app_id=YOUR_APP_ID, app_secret=YOUR_APP_SECRET)
-clef_user_id = api.logout_user(logout_token=logout_token)
+clef_id = clef.get_logout_information(logout_token=logout_token)
 ```
+
+For what to do after getting a user who's logging out's `clef_id`, see our
+documentation on [Database
+logout](http://docs.getclef.com/v1.0/docs/database-logout).
+
 
 Sample App
 ----------
+
 This repo includes a one-file sample app that uses the Flask framework and demonstrates authentication. To try it out:    
 * Install Flask if you don't already have it      
 `$ pip install Flask`    

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The Clef API lets you retrieve information about a user after they log in to you
 
 #### Add the Clef button
 
-The [Clef button](http://docs.getclef.com/v1.0/docs/adding-the-clef-button) has a `data-redirect-url`, which is where you can retrieve user information.
+The [Clef button](http://docs.getclef.com/v1.0/docs/adding-the-clef-button) has a `data-redirect-url`, which is where you'll be interacting with the Clef API.
 
 Usage
 -----

--- a/clef/__init__.py
+++ b/clef/__init__.py
@@ -1,11 +1,16 @@
 from .clef import (
-        ClefAPI, 
-        ClefError, 
-        ClefSetupError, 
-        ClefCodeError, 
-        ClefTokenError, 
-        ClefServerError, 
-        ClefConnectionError, 
-        ClefLogoutError, 
-        ClefNotFoundError
+        APIError,
+        InvalidAppIDError,
+        InvalidAppSecretError,
+        InvalidOAuthCodeError,
+        InvalidOAuthTokenError,
+        InvalidLogoutTokenError,
+        ServerError,
+        ConnectionError,
+        NotFoundError,
+        ClefAPI,
+        initialize,
+        get_login_information,
+        get_logout_information,
+        clef_api
 )

--- a/clef/clef.py
+++ b/clef/clef.py
@@ -3,8 +3,10 @@ import requests
 class APIError(Exception): pass
 class InvalidAppIDError(APIError): pass
 class InvalidAppSecretError(APIError): pass
+class InvalidAppError(APIError): pass
 class InvalidOAuthCodeError(APIError): pass
 class InvalidOAuthTokenError(APIError): pass
+class InvalidLogoutHookURLError(APIError): pass
 class InvalidLogoutTokenError(APIError): pass
 class ServerError(APIError): pass
 class ConnectionError(APIError): pass
@@ -15,12 +17,13 @@ class NotFoundError(APIError): pass
 # Clef 403 error strings mapped to the right class of error to raise
 MESSAGE_TO_ERROR_MAP = {
     'Invalid App ID.': InvalidAppIDError,
-    'Invalid App.': InvalidAppIDError,
     'Invalid App Secret.': InvalidAppSecretError,
+    'Invalid App.': InvalidAppError,
     'Invalid OAuth Code.': InvalidOAuthCodeError,
     'Invalid token.': InvalidOAuthTokenError,
+    'Invalid logout hook URL.': InvalidLogoutHookURLError,
     'Invalid Logout Token.': InvalidLogoutTokenError,
-    None: APIError,
+    None: APIError
 }
 
 def clef_error_check(func_to_decorate):
@@ -51,7 +54,11 @@ def raise_right_error(response):
         raise error_class(message)
     if response.status_code == 400:
         message = response.json().get('error')
-        raise InvalidLogoutTokenError(message)
+        error_class = MESSAGE_TO_ERROR_MAP[message]
+        if error_class:
+            raise error_class(message)
+        else:
+            raise InvalidLogoutTokenError(message)
     if response.status_code == 404:
         raise NotFoundError('Unable to retrieve the page. Are you sure the Clef API endpoint is configured right?')
     raise APIError

--- a/clef/clef.py
+++ b/clef/clef.py
@@ -1,47 +1,26 @@
 import requests
 
-class ClefError(Exception):
-    """Base error."""
-    pass
+class APIError(Exception): pass
+class InvalidAppIDError(APIError): pass
+class InvalidAppSecretError(APIError): pass
+class InvalidOAuthCodeError(APIError): pass
+class InvalidOAuthTokenError(APIError): pass
+class InvalidLogoutTokenError(APIError): pass
+class ServerError(APIError): pass
+class ConnectionError(APIError): pass
+class NotFoundError(APIError): pass
 
-class ClefSetupError(Exception):
-    """Invalid App Id or App secret."""
-    pass
 
-class ClefCodeError(Exception):
-    """OAuth handshake failed. Clef unable to exchange code for access token."""
-    pass
 
-class ClefTokenError(Exception):
-    """Clef unable to exchange token for user information."""
-    pass 
-
-class ClefServerError(Exception):
-    """Clef servers are down."""
-    pass 
-
-class ClefConnectionError(Exception):
-    """No network connection detected."""
-    pass 
-
-class ClefLogoutError(Exception):
-    """Logout hook does not match app domain or has not been configured correctly."""
-    pass 
-
-class ClefNotFoundError(Exception):
-    """Invalid API endpoint was requested."""
-    pass 
-
-# Clef 403 error strings mapped to the right class of error to raise 
-message_to_error_map = {
-    'Invalid App ID.': ClefSetupError,
-    'Invalid App.': ClefSetupError,
-    'Invalid App Secret.': ClefSetupError,
-    'Invalid OAuth Code.': ClefCodeError,
-    'Invalid token.' : ClefTokenError,
-    'Invalid Logout Token.': ClefLogoutError,
-    None: ClefError,
-
+# Clef 403 error strings mapped to the right class of error to raise
+MESSAGE_TO_ERROR_MAP = {
+    'Invalid App ID.': InvalidAppIDError,
+    'Invalid App.': InvalidAppIDError,
+    'Invalid App Secret.': InvalidAppSecretError,
+    'Invalid OAuth Code.': InvalidOAuthCodeError,
+    'Invalid token.': InvalidOAuthTokenError,
+    'Invalid Logout Token.': InvalidLogoutTokenError,
+    None: APIError,
 }
 
 def clef_error_check(func_to_decorate):
@@ -50,42 +29,41 @@ def clef_error_check(func_to_decorate):
         try:
             response = func_to_decorate(*args, **kwargs)
         except requests.exceptions.RequestException:
-            raise ClefConnectionError(
+            raise ConnectionError(
                 'Clef encountered a network connectivity problem. Are you sure you are connected to the Internet?'
             )
         else:
             raise_right_error(response)
-        return response.json() # decode json  
-    return wrapper 
+        return response.json() # decode json
+    return wrapper
 
 def raise_right_error(response):
     """Raise appropriate error when bad response received."""
     if response.status_code == 200:
-        return 
+        return
     if response.status_code == 500:
-        raise ClefServerError('Clef servers are down.')
+        raise ServerError('Clef servers are down.')
     if response.status_code == 403:
         message = response.json().get('error')
-        error_class = message_to_error_map[message]
-        if error_class == ClefTokenError:
+        error_class = MESSAGE_TO_ERROR_MAP[message]
+        if error_class == InvalidOAuthTokenError:
             message = 'Something went wrong at Clef. Unable to retrieve user information with this token.'
         raise error_class(message)
     if response.status_code == 400:
         message = response.json().get('error')
-        raise ClefLogoutError(message)
+        raise InvalidLogoutTokenError(message)
     if response.status_code == 404:
-        raise ClefNotFoundError('Unable to retrieve the page. Are you sure the Clef API endpoint is configured right?')
-    # too restrictive? 
-    raise ClefError
+        raise NotFoundError('Unable to retrieve the page. Are you sure the Clef API endpoint is configured right?')
+    raise APIError
 
 
 class ClefAPI(object):
-    def __init__(self, app_id, app_secret, root=None):
+    def __init__(self, app_id=None, app_secret=None, root=None):
         if not root:
             root = 'https://clef.io/api'
         version = 'v1'
-        self.api_key = app_id
-        self.api_secret = app_secret 
+        self.app_id = app_id
+        self.app_secret = app_secret
         self.api_endpoint = '/'.join([root, version])
         self.authorize_url = '/'.join([self.api_endpoint, 'authorize'])
         self.info_url = '/'.join([self.api_endpoint, 'info'])
@@ -96,36 +74,54 @@ class ClefAPI(object):
         """Return response from Clef API call."""
         request_params = {}
         if method == 'GET':
-            request_params['params'] = params 
+            request_params['params'] = params
         elif method == 'POST':
-            request_params['data'] = params 
+            request_params['data'] = params
         response = requests.request(method, url, **request_params)
-        return response 
+        return response
 
-    def get_user_info(self, code=None, access_token=None):
+    def get_login_information(self, code=None, access_token=None):
         """Return Clef user info after exchanging code for OAuth token."""
         if access_token:
             return self._get_user_info(access_token)
         # do the handshake to get token
-        data = dict(code=code, app_id=self.api_key, app_secret=self.api_secret)
-        token_response = self._call('POST', self.authorize_url, params=data) # json decoded
-        access_token = token_response.get('access_token')
+        access_token = self._get_access_token(code)
         # make request with token to get user details
-        info_response = self._call('GET', self.info_url, params={'access_token': access_token})
-        user_info = info_response.get('info')
-        return user_info 
+        return self._get_user_info(access_token)
+
+    def _get_access_token(self, code):
+        data = dict(code=code, app_id=self.app_id, app_secret=self.app_secret)
+        token_response = self._call('POST', self.authorize_url, params=data) # json decoded
+        return token_response.get('access_token')
 
     def _get_user_info(self, access_token):
-        """Return Clef user info. Bypass OAuth handshake."""
-        # TODO: check to see if access tokens can be stored by applications or if they expire
+        """Return Clef user info."""
         info_response = self._call('GET', self.info_url, params={'access_token': access_token})
         user_info = info_response.get('info')
         return user_info
 
-    def logout_user(self, logout_token):
+    def get_logout_information(self, logout_token):
         """Return Clef user info after exchanging logout token."""
-        data = dict(logout_token=logout_token, app_id=self.api_key, app_secret=self.api_secret)
+        data = dict(logout_token=logout_token, app_id=self.app_id, app_secret=self.app_secret)
         logout_response = self._call('POST', self.logout_url, params=data)
         clef_user_id = logout_response.get('clef_id')
         return clef_user_id
- 
+
+
+clef_api = ClefAPI()
+
+def initialize(app_id=None, app_secret=None):
+    global clef_api
+    if not clef_api:
+        clef_api = ClefAPI()
+    clef_api.app_id = app_id
+    clef_api.app_secret = app_secret
+
+def get_login_information(code):
+    global clef_api
+    return clef_api.get_login_information(code=code)
+
+def get_logout_information(logout_token):
+    global clef_api
+    return clef_api.get_logout_information(logout_token)
+

--- a/sample_app.py
+++ b/sample_app.py
@@ -1,16 +1,17 @@
 #!/usr/bin/env python
-import time 
-from flask import Flask, render_template, request, url_for, redirect, session
-from clef import clef 
+import time
+from flask import Flask, render_template, request, url_for, redirect, session, current_app
+import clef
 
 app = Flask(__name__)
 app.secret_key = 'my_secret_key'
 
-# replace these test credentials with your own 
+# replace these test credentials with your own
 # make sure to also replace the data-app-id attribute in your clef button - line 36 in templates/index.html
-CLEF_APP_ID ='4f318ac177a9391c2e0d221203725ffd'  
+CLEF_APP_ID ='4f318ac177a9391c2e0d221203725ffd'
 CLEF_APP_SECRET = '2125d80f4583c52c46f8084bcc030c9b'
 
+clef.initialize(CLEF_APP_ID, CLEF_APP_SECRET)
 
 @app.route('/')
 def home(name=None, error=None):
@@ -20,43 +21,43 @@ def home(name=None, error=None):
     if session.get('error'):
         error = session['error']
         del session['error']
-    
+
     return render_template('index.html', name=name, error=error)
 
 # the data-redirect-url attribute you set in your clef button - line 36 in templates/index.html
 @app.route('/oauth_callback')
 def clef_oauth_callback():
-    # configure the client 
+    # configure the client
     code = request.args.get('code')
-    client = clef.ClefAPI(app_id=CLEF_APP_ID, app_secret=CLEF_APP_SECRET)
     # call to get user information handles the OAuth handshake
     try:
-        user_dict = client.get_user_info(code=code)
+        user_dict = clef.get_login_information(code=code)
     # customize how you want to handle errors
-    except (clef.ClefSetupError, 
-            clef.ClefTokenError, 
-            clef.ClefCodeError, 
-            clef.ClefServerError, 
-            clef.ClefConnectionError,
-            clef.ClefError) as e:
-            pass
+    except (clef.InvalidAppIDError,
+            clef.InvalidAppSecretError,
+            clef.InvalidOAuthCodeError,
+            clef.InvalidOAuthTokenError,
+            clef.ServerError,
+            clef.ConnectionError) as e:
+        current_app.logger.error(e)
+    except clef.APIError as e:
+        current_app.logger.error(e)
     # client returns a dictionary of user details
     else:
         name = user_dict.get('first_name')
-        session['first_name'] = name 
+        session['first_name'] = name
         session['clef_id'] = user_dict.get('id')
-        session['logged_in_at'] = time.time() 
+        session['logged_in_at'] = time.time()
     return redirect(url_for('home'))
 
 @app.route('/logout', methods=['GET', 'POST'])
 def logout():
     session.clear()
     if request.method == 'POST':
-        # Clef is notifying you that a user has logged out from their phone so log them out from your site 
+        # Clef is notifying you that a user has logged out from their phone so log them out from your site
         logout_token = request.form.get('logout_token')
-        client = clef.ClefAPI(app_id=CLEF_APP_ID, app_secret=CLEF_APP_SECRET)
-        clef_user_id = client.logout_user(logout_token=logout_token) 
-        # use the clef_user_id to look up the user in your database and update their logged_out_at field
+        clef_id = clef.get_logout_information(logout_token=logout_token)
+        # use the clef_id to look up the user in your database and update their logged_out_at field
         # http://docs.getclef.com/v1.0/docs/database-logout
     return redirect(url_for('home'))
 


### PR DESCRIPTION
This PR: 
- Creates module level functions for interacting with the API wrapper. This is consistent with some other python wrapper libraries like Stripe's. 
- Removes the "Clef*" prefix before custom exception classes. I did this because they are already namespaced in the `clef` module. 

I also updated the README, tests and sample app to use the module level functions. 
